### PR TITLE
Support async drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,38 @@ Different devices have different characteristics, and require different
 capabilities of the driver. A given driver should use exactly one of
 these classes.
 
+### Driver base class
+
+[Driver](./docs/driver.md)
+
+This is the base class for all the driver classes. Common methods and
+parameters are documented here.
+
 ### Polled driver
 
+[PolledDriver](./docs/polled.md)
+
 This is for drivers which can read single values from the device when
-requested, and don't need to perform any setup beyond initial connection
-to the device. This driver class is not suitable for devices which may
+requested. This driver class is not suitable for devices which may
 produce data asynchronously.
 
-[Documentation is here.](./docs/polled.md)
+### Async driver
+
+[AsyncDriver](./docs/async.md)
+
+This is for drivers which produce data values asynchronously and cannot
+be polled.
+
+## Utility functions
+
+### Logging
+
+[Debug](./docs/debug.md)
+
+This class provides simple configurable logging.
+
+### Buffer conversions
+
+[BufferX](./docs/bufferx.md)
+
+This object provides static functions to construct Buffers.

--- a/docs/async.md
+++ b/docs/async.md
@@ -1,0 +1,87 @@
+# Async driver
+
+This driver class supports read-only, asynchronous drivers. This is for
+devices where data arrives without polling, and where requesting data is
+not possible. It may be necessary for the driver to subscribe to the
+device to start the data flowing.
+
+Drivers are not expected to be intelligent, just to subscribe to the
+device and return the data as it arrives. Report-by-exception handling
+happens in the Edge Agent.
+
+## Outline
+
+The basic structure of a driver using this class looks like this:
+
+```javascript
+import { AsyncDriver } from "@amrc-factoryplus/edge-driver";
+
+/* This is the handler interface */
+class Handler {
+    
+    /* This is called to create a handler */
+    static create (driver, conf) { }
+
+    /* The constructor is private */
+    
+    /* Methods required by Driver */
+    connect () { }
+    parseAddr (addr) { }
+    subscribe (specs) { }
+    async close () { }
+}
+
+const drv = new AsyncDriver({
+    env:        process.env,
+    handler:    Handler,
+});
+drv.run();
+```
+
+A handler class is required; this implements the driver functionality
+and must support the documented interface. Then a generic driver object
+is created passing the handler class. Every time the Edge Agent sends a
+new config, the library will destroy the current handler and create a
+new one. The driver will then call the `connect` method on the handler
+which should attempt to connect to the southbound device.
+
+The driver object needs access to the process environment to communicate
+with the Edge Agent; this assumes the standard environment variables are
+being used.
+
+The documented API is detailed below. Any other methods or properties
+are not documented and must not be relied on.
+
+## `AsyncDriver` class
+
+An `AsyncDriver` class represents the whole driver process, and handles
+communication with the Edge Agent. Methods documented below can be
+called from the handler class. AsyncDriver inherits from
+[Driver](./driver.md).
+
+### `constructor`
+
+    const driver = new AsyncDriver({
+        env:        process.env,
+        handler:    HandlerClass,
+    });
+
+The `env` property is documented in the Driver documentation.
+
+The `handler` property gives the handler class to use. This must support
+the `Handler` interface documented for [Driver](./driver.md). The
+AsyncDriver does not expect any additional methods.
+
+### `data`
+
+    driver.data(spec, buffer);
+
+This is called by the handler to push data to the driver. The `spec` is
+an address spec as returned from `parseAddr`. If a spec (or an address,
+for handlers with no `parseAddr` method) is supplied which the driver is
+not expecting the call will simply be ignored. The `buffer` is a Buffer
+containing the data to report.
+
+This method returns a Promise which resolves when the data has been
+successfully written to the Edge Agent, however normally it will not be
+important to await this.

--- a/docs/bufferx.md
+++ b/docs/bufferx.md
@@ -1,0 +1,22 @@
+# Buffer construction functions
+
+    import { BufferX } from "@amrc-factoryplus/edge-driver";
+
+    constt buf = BufferX.fromDoubleLE(24.5);
+
+This object provides static functions for constructing Buffers. The
+following functions are provided. In this list `%e` indicates either
+`BE` or `LE` for big- or little-endian conversions. See the `write*`
+methods on Buffer for full details.
+
+    fromBigInt64%e
+    fromBigUInt64%e
+    fromInt32%e
+    fromUInt32%e
+    fromInt16%e
+    fromUInt16%e
+    fromInt8
+    fromUInt8
+    fromDouble%e
+    fromFloat%e
+    fromJSON

--- a/docs/driver.md
+++ b/docs/driver.md
@@ -144,7 +144,8 @@ This method is optional.
 
 This method parses an address string and returns a data structure
 suitable for the handler's internal purposes. This will be passed to the
-driver later in place of the address.
+driver later in place of the address. This method may be called at any
+time; in particular it may be called before the handler has connected. 
 
 The string should be validated for syntax, but no IO can be performed.
 This method should be a pure function: it should produce the same result

--- a/docs/driver.md
+++ b/docs/driver.md
@@ -17,7 +17,7 @@ The basic structure of any driver using this library looks like this:
         static create (driver, conf) { }
 
         /* This method is required */
-        connect () { }
+        async connect () { }
 
         /* These properties and methods are optional */
         static validAddrs;
@@ -87,32 +87,15 @@ environment. The handler class should use this for logging.
 This method starts the communication with the Edge Agent. It does not
 return.
 
-### `connUp`
-    
-    driver.connUp();
-
-This should be called by the handler to report a successful southbound
-connection.
-
 ### `connFailed`
 
     driver.connFailed();
 
-This should be called by the handler to report a failure to connect to
-the southbound device. The handler should not attempt to reconnect and
-should not produce any more data after calling this until the driver has
-called `connect` again. A successful connection but bad credentials
-should be reported with `connUnauth`.
-
-### `connUnauth`
-    
-    driver.connUnauth();
-
-This should be called by the handler to report that it has successfully
-connected to the southbound device but it cannot authenticate, or is not
-authorised to do what it needs to do. The handler should not attempt to
-reconnect and should not produce any more data until after the driver
-has called `connect` again.
+This should be called by the handler to report that the connection to
+the southbound device has failed. The handler should not call this
+unless it has previously returned `UP` from the `connect` method. The
+handler should not attempt to reconnect or produce any more data until
+the driver has reconnected.
 
 ## `Handler` interface
 
@@ -134,13 +117,13 @@ This method should not attempt to connect to the southbound device.
 
 ### `connect`
 
-    handler.connect();
+    const status = await handler.connect();
 
 This is called by the driver to initiate connection to the southbound
-device. This must eventually result in a call to one of the `conn...`
-methods on the driver to report the connection state. The method should
-not attempt to retry if the initial connection attempt fails. The driver
-may call this method again if the handler reports a connection failure.
+device. This method is async; it returns a Promise to a string. This
+should be one of the status values in the Edge Driver protocol
+documentation. A return value other than `"UP"` will cause the driver to
+reconnect after a delay.
 
 ### `validAddrs`
 

--- a/docs/driver.md
+++ b/docs/driver.md
@@ -1,0 +1,200 @@
+# Generic driver interface
+
+The drivers provided by the library are derived from a common base
+class. This supports connection to the Edge Agent and communication
+with the user-provided handler class.
+
+## Outline
+
+The basic structure of any driver using this library looks like this:
+
+    /* Import an appropriate subclass */
+    import { Driver } from "@amrc-factoryplus/edge-driver";
+
+    /* This implements the driver functionality */
+    class Handler {
+        /* This is called to construct a handler */
+        static create (driver, conf) { }
+
+        /* This method is required */
+        connect () { }
+
+        /* These properties and methods are optional */
+        static validAddrs;
+        parseAddr (addr) { }
+        async subscribe (specs) { }
+        async close () { }
+    }
+    
+    /* Don't use Driver directly, use a subclass */
+    const drv = new Driver({
+        env:        process.env,
+        handler:    Handler,
+    });
+    drv.run();
+
+A handler class is required; this implements the driver functionality
+and must support the interface required by the Driver subclass in use.
+Then a generic driver object is created passing the handler class. Every
+time the Edge Agent sends a new config, the library will destroy the
+current handler and create a new one. The driver will then call the
+`connect` method on the handler which should attempt to connect to the
+southbound device. The handler reports connection status and received
+data by calling methods on the driver.
+
+The driver object needs access to the process environment to communicate
+with the Edge Agent; this assumes the standard environment variables are
+being used.
+
+The documented API is detailed below. Any other methods or properties
+are not documented and must not be relied on.
+
+## `Driver` class
+
+A `Driver` object represents the whole driver process, and handles
+communication with the Edge Agent. The class Driver itself should be
+considered abstract; create instances of subclasses. Methods documented
+below can be called from the handler class.
+
+### `constructor`
+
+    const driver = new Driver({
+        env:        process.env,
+        handler:    HandlerClass,
+    });
+
+The `env` property should be `process.env`, or a suitable substitute.
+The keys `EDGE_MQTT`, `EDGE_USERNAME` and `EDGE_PASSWORD` will be used
+to initiate communication with the Edge Agent. The key `VERBOSE` will be
+used to configure the logger.
+
+The `handler` property specifies the handler class to implement the
+functionality of this driver. This must support the interface required
+by the Driver subclass in use, which will be a subinterface of the
+`Handler` interface below.
+
+### `debug`
+
+    driver.debug.log(channel, message);
+
+This property is a [Debug object](./debug.md) configured from the
+environment. The handler class should use this for logging.
+
+### `run`
+
+    driver.run();
+
+This method starts the communication with the Edge Agent. It does not
+return.
+
+### `connUp`
+    
+    driver.connUp();
+
+This should be called by the handler to report a successful southbound
+connection.
+
+### `connFailed`
+
+    driver.connFailed();
+
+This should be called by the handler to report a failure to connect to
+the southbound device. The handler should not attempt to reconnect and
+should not produce any more data after calling this until the driver has
+called `connect` again. A successful connection but bad credentials
+should be reported with `connUnauth`.
+
+### `connUnauth`
+    
+    driver.connUnauth();
+
+This should be called by the handler to report that it has successfully
+connected to the southbound device but it cannot authenticate, or is not
+authorised to do what it needs to do. The handler should not attempt to
+reconnect and should not produce any more data until after the driver
+has called `connect` again.
+
+## `Handler` interface
+
+The handlers required by Driver subclasses all need to implement this
+interface, in addition to any further requirement imposed by the
+subclass.
+
+### `create`
+
+    const handler = HandlerClass.create(driver, conf);
+
+This is a static method called to construct a handler object. The method
+is passed the driver object this handler belongs to and the
+configuration received from the Edge Agent. The method should validate
+the configuration and return `undefined` if it is invalid. Otherwise it
+should construct and return a handler object.
+
+This method should not attempt to connect to the southbound device.
+
+### `connect`
+
+    handler.connect();
+
+This is called by the driver to initiate connection to the southbound
+device. This must eventually result in a call to one of the `conn...`
+methods on the driver to report the connection state. The method should
+not attempt to retry if the initial connection attempt fails. The driver
+may call this method again if the handler reports a connection failure.
+
+### `validAddrs`
+
+    const valid = HandlerClass.validAddrs.get(addr);
+
+This property is optional.
+
+If a handler class has this property, it should be a Set of strings
+indicating valid addresses. This is only suitable for drivers which have
+a fixed set of constant addresses, but can be used instead of a
+`parseAddr` method which only validates.
+
+### `parseAddr`
+
+    const spec = handler.parseAddr(addr);
+
+This method is optional.
+
+This method parses an address string and returns a data structure
+suitable for the handler's internal purposes. This will be passed to the
+driver later in place of the address.
+
+The string should be validated for syntax, but no IO can be performed.
+This method should be a pure function: it should produce the same result
+every time for the same argument. If this method is not provided then
+address strings are passed through as-is.
+
+### `subscribe`
+
+    await handler.subscribe(specs);
+
+This method is optional.
+
+If this method exists it will be called whenever the Edge Agent has
+changed the list of addresses it is interested in. The method is passed
+an Array of specs as returned from `parseAddr`. The handler can use this
+to set up subscriptions to the southbound device.
+
+### `close`
+
+    await handler.close();
+
+This method is optional.
+
+If this method exists it is called when a new configuration is received,
+just before the old handler object will be unreferenced. The result will
+be awaited before a new handler is created. This should perform any
+cleanup (closing connections, etc.) and ensure this is complete before
+the returned Promise resolves.
+
+If and when the [TC39 Explicit Resource Management
+proposal](https://github.com/tc39/proposal-explicit-resource-management)
+is accepted and becomes available in Node.js, the `close` method is
+likely to be supplemented by `Symbol.asyncDispose`. A handler object
+implementing `@@asyncDispose` or `@@dispose` should clean up correctly
+when any single disposal method is called.
+

--- a/docs/polled.md
+++ b/docs/polled.md
@@ -3,8 +3,7 @@
 This driver class supports read-only, polled drivers. That is, drivers
 which can read data from a southbound device but cannot write data back,
 and where the Edge Agent handles the poll loop. This version is not
-suitable for drivers where data arrives asynchronously, or where a
-subscription must be made to the southbound device.
+suitable for drivers where data arrives asynchronously.
 
 For a polled driver, the Edge Agent runs the polling loop. It sends a
 message to the driver to request a poll of certain addresses; the
@@ -19,37 +18,26 @@ The basic structure of a driver using this class looks like this:
 ```javascript
 import { PolledDriver } from "@amrc-factoryplus/edge-driver";
 
+/* This is the handler interface */
 class Handler {
-    /* This is the handler interface */
+    
+    /* This is called to create a handler */
+    static create (driver, conf) { }
 
+    /* The constructor is private */
+    
+    /* Methods required by Driver */
+    connect () { }
     parseAddr (addr) { }
-    async poll (spec) { }
     async close () { }
 
-    /* These methods are private between the Handler class and the
-     * createHandler function. */
-
-    constructor (driver, conf) {
-        this.driver = driver;
-        this.conf = conf;
-    }
-
-    async run () {
-        /* Connect to southbound device */
-        this.driver.setStatus("UP");
-    }
-}
-
-function createHandler (driver, conf) {
-    /* Validate config */
-    const handler = new Handler(driver, conf);
-    handler.run();
-    return handler;
+    /* Methods required by PolledDriver */
+    async poll (spec) { }
 }
 
 const drv = new PolledDriver({
     env:        process.env,
-    handler:    createHandler,
+    handler:    Handler,
     serial:     true,
 });
 drv.run();
@@ -57,13 +45,14 @@ drv.run();
 
 A handler class is required; this implements the driver functionality
 and must support the documented interface. Then a generic driver object
-is created, and passed a factory function to build a handler. Every time
-the Edge Agent sends a new config, the library will destroy the current
-handler and create a new one. The driver object needs access to the
-process environment to communicate with the Edge Agent; this assumes the
-standard environment variables are being used. Finally the `run` method
-must be called on the driver object to start the communication; this
-will not return.
+is created passing the handler class. Every time the Edge Agent sends a
+new config, the library will destroy the current handler and create a
+new one. The driver will then call the `connect` method on the handler
+which should attempt to connect to the southbound device.
+
+The driver object needs access to the process environment to communicate
+with the Edge Agent; this assumes the standard environment variables are
+being used.
 
 The documented API is detailed below. Any other methods or properties
 are not documented and must not be relied on.
@@ -71,82 +60,33 @@ are not documented and must not be relied on.
 ## `PolledDriver` class
 
 A `PolledDriver` class represents the whole driver process, and handles
-communication with the Edge Agent.
+communication with the Edge Agent. Methods documented below can be
+called from the handler class. PolledDriver inherits from
+[Driver](./driver.md).
 
 ### `constructor`
 
     const driver = new PolledDriver({
         env:        process.env,
-        handler:    handlerFactory,
+        handler:    HandlerClass,
         serial:     true,
     });
 
-The `env` property should be `process.env`, or a suitable substitute.
-The keys `EDGE_MQTT`, `EDGE_USERNAME` and `EDGE_PASSWORD` will be used
-to initiate communication with the Edge Agent. The key `VERBOSE` will be
-used to configure the logger.
+The `env` property is documented in the `Driver` documentation.
 
-The `handler` function creates a handler object when the driver has been
-sent a new configuration. The function takes two arguments, the driver
-object itself and the configuration. If the function returns a false
-value the driver will report a `CONF` error.
+The `handler` property gives the handler class to use. This must support
+the `PolledHandler` interface documented below.
 
 The `serial` property is optional. If it is true, this requests that the
 driver not poll more than one address at a time. Poll requests will be
 queued and handled in order. If it is false or omitted poll requests may
 be made in parallel.
 
-### `debug`
+## `PolledHandler` interface
 
-    driver.debug.log(channel, message);
-
-This property is a [Debug object](./debug.md) configured from the
-environment. The handler class should use this for logging.
-
-### `setStatus`
-
-    driver.setStatus("UP");
-
-This method should be called by the handler to report the status of its
-southbound connection, or other problems. The argument is a string;
-valid values are:
-
-Status | Meaning
----|---
-`UP`    | We are successfully connected southbound.
-`CONN`  | There is a problem connecting southbound.
-`AUTH`  | There is a problem authenticating to the southbound device.
-`ERR`   | Some other error has occurred.
-
-### `run`
-
-    driver.run();
-
-This method starts the communication with the Edge Agent. It does not
-return.
-
-## Handler interface
-
-The handler factory function accepts a driver object and a
-configuration, and returns a handler or false. Objects returned from the
-factory function must support the interface specified below. The
-constructor is called by the factory function, so is not specified as
-part of the interface.
-
-The factory function needs to initiate connection to the southbound
-device; it is not good practice for a constructor to have external
-effects, so this will probably mean calling a method on the handler
-object before returning it. This should eventually result in a call to
-the driver `setStatus` method.
-
-### `parseAddr`
-
-    const spec = handler.parseAddr(addr);
-
-This method parses an address string and returns a data structure
-suitable to use for polling the southbound device. Returning the same
-string is acceptable. The string should be validated for syntax, but no
-IO can be performed.
+The handler class passed to a PolledDriver must implement the `Handler`
+interface documented in [the Driver class](./driver.md), and also the
+methods below.
 
 ### `poll`
 
@@ -156,21 +96,4 @@ This method is `async`; its return value is wrapped in a Promise. The
 method accepts a spec as returned from `parseAddr`, reads from the
 southbound device, and returns a buffer. If the read cannot be
 performed, return `undefined`.
-
-### `close`
-
-    await handler.close();
-
-This method is optional, and if present is called when a new
-configuration is received, just before the old handler object will be
-unreferenced. The result will be awaited before a new handler is
-created. This should perform any cleanup (closing connections, etc.) and
-ensure this is complete before the returned Promise resolves.
-
-If and when the [TC39 Explicit Resource Management
-proposal](https://github.com/tc39/proposal-explicit-resource-management)
-is accepted and becomes available in Node.js, the `close` method is
-likely to be supplemented by `Symbol.asyncDispose`. A handler object
-implementing `@@asyncDispose` or `@@dispose` should clean up correctly
-when any single disposal method is called.
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -5,7 +5,7 @@
 
 import { Driver } from "./driver.js";
 
-export class AsyncDriver {
+export class AsyncDriver extends Driver {
     constructor (opts) {
         super(opts);
     }

--- a/lib/async.js
+++ b/lib/async.js
@@ -1,0 +1,22 @@
+/* AMRC Connectivity Stack
+ * Edge Agent driver library
+ * Copyright 2024 AMRC
+ */
+
+import { Driver } from "./driver.js";
+
+export class AsyncDriver {
+    constructor (opts) {
+        super(opts);
+    }
+
+    async data (spec, buf) {
+        this.log("DATA %O", buf);
+
+        const dtopic = this.topics?.get(spec);
+        if (!dtopic) return;
+
+        const mtopic = this.topic("data", dtopic);
+        return this.mqtt.publishAsync(mtopic, buf);
+    }
+}

--- a/lib/bufferx.js
+++ b/lib/bufferx.js
@@ -1,0 +1,35 @@
+/*
+ * ACS edge driver library
+ * Buffer conversion functions
+ * Copyright 2024 AMRC
+ */
+
+import { Buffer } from "buffer";
+
+const types = {
+    BigInt64:   8,
+    BigUInt64:  8,
+    Int32:      4,
+    UInt32:     4,
+    Int16:      2,
+    UInt16:     2,
+    Int8:       1,
+    UInt8:      1,
+    Double:     8,
+    Float:      4,
+};
+
+const ended = Object.entries(types)
+    .flatMap(([t, s]) =>
+        s > 1 ? [[`${t}LE`, s], [`${t}BE`, s]] : [[t, s]]);
+
+export const BufferX = Object.fromEntries([
+    ...(ended.map(([t, s]) => [`from${t}`, Buffer.prototype[`write${t}`], s])
+        .map(([n, w, s]) => 
+            [n, v => {
+                const buf = Buffer.allocUnsafe(s);
+                w.call(buf, v);
+                return buf;
+            }])),
+    ["fromJSON", j => Buffer.from(JSON.stringify(j))],
+]);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -12,7 +12,7 @@ export class Driver {
         this.createHandler = opts.handler;
 
         this.status = "DOWN";
-        this.addrs = null;
+        this.clearAddrs();
 
         const { env } = opts;
         this.debug = new Debug({ verbose: env.VERBOSE });
@@ -69,27 +69,69 @@ export class Driver {
             this.mqtt.publish(this.topic("status"), st);
     }
 
-    setAddrs (pkt) {
+    clearAddrs () {
+        this.addrs = null;
+        this.topics = null;
+    }
+
+    async setAddrs (pkt) {
         if (!this.handler) {
             this.log("Received addrs without handler");
             return false;
         }
+
+        /* Until we have resubscribed we have no addrs */
+        this.clearAddrs();
 
         if (pkt.version != 1) {
             this.log("Bad addr config version: %s", pkt.version);
             return false;
         }
         
-        const parsed = Object.entries(pkt.addrs)
-            .map(([t, a]) => [t, this.handler.parseAddr(a)]);
-
-        if (parsed.some(([, f]) => !f)) {
-            this.log("BAD ADDRS: %O", pkt.addrs);
+        if (!await this.handleAddrs(pkt.addrs))
             return false;
-        }
         
         this.addrs = new Map(parsed);
+        this.topics = new Map(parsed.map(([t, s]) => [s, t]));
         this.log("Set addrs: %O", this.addrs);
+        return true;
+    }
+
+    handleAddrs (addrs) {
+        const { handler } = this;
+
+        const entries = Object.entries(pkt.addrs);
+
+        if (handler.validAddrs) {
+            const bad = entries.filter(([t, a]) => !handler.validAddrs.has(a));
+            if (bad.length) {
+                this.log("Invalid addresses: %o", bad);
+                return false;
+        }
+
+        if (!handler.parseAddr)
+            return entries;
+
+        const parsed = entries.map(([t, a]) => [t, handler.parseAddr(a)]);
+        if (!await this.subscribe(parsed.map(([, s]) => s)))
+            return false;
+
+        return true;
+    }
+
+    async subscribe (specs) {
+        if (specs.some(s => !s)) {
+            this.log("Invalid addresses: %O", pkt.addrs);
+            return false;
+        }
+
+        if (handler.subscribe) {
+            if (!await handler.subscribe(specs)) {
+                this.log("Handler subscription failed");
+                return false;
+            }
+        }
+
         return true;
     }
 
@@ -114,7 +156,7 @@ export class Driver {
                 const conf = this.json(p);
                 this.log("CONF: %O", conf);
 
-                this.addrs = null;
+                this.clearAddrs();
                 await this.handler?.close?.();
 
                 this.handler = conf && this.createHandler(this, conf);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -69,6 +69,10 @@ export class Driver {
             this.mqtt.publish(this.topic("status"), st);
     }
 
+    connUp () { this.setStatus("UP"); }
+    connFailed () { this.setStatus("CONN"); }
+    connUnauth () { this.setStatus("AUTH"); }
+
     clearAddrs () {
         this.addrs = null;
         this.topics = null;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -63,6 +63,28 @@ export class Driver {
         return mqtt;
     }
 
+    setupHandler (conf) {
+        if (!conf) return;
+
+        this.handler = this.HandlerClass.create(this, conf);
+        if (!this.handler) return;
+
+        const valid = this.handler.constructor.validAddrs;
+        const parse = this.handler.parseAddrs ?? a => a;
+
+        this.handleAddrs = entries => {
+            if (valid) {
+                const bad = entries.filter(([t, a]) => !valid.has(a));
+                if (bad.length) {
+                    this.log("Invalid addresses: %o", bad);
+                    return;
+                }
+            }
+
+            return entries.map(([t, a]) => [t, parse(a)]);
+        };
+    }
+
     setStatus (st) {
         this.status = st;
         if (this.mqtt.connected)
@@ -92,35 +114,17 @@ export class Driver {
             return false;
         }
         
-        if (!await this.handleAddrs(pkt.addrs))
+        const parsed = this.handleAddrs(Object.entries(pkt.addrs));
+        const specs = parsed.map(([, s]) => s);
+        if (parsed.some(s => !s))
+            return false;
+
+        if (!await this.subscribe(specs))
             return false;
         
         this.addrs = new Map(parsed);
         this.topics = new Map(parsed.map(([t, s]) => [s, t]));
         this.log("Set addrs: %O", this.addrs);
-        return true;
-    }
-
-    async handleAddrs (addrs) {
-        const { handler } = this;
-
-        const entries = Object.entries(pkt.addrs);
-
-        if (handler.validAddrs) {
-            const bad = entries.filter(([t, a]) => !handler.validAddrs.has(a));
-            if (bad.length) {
-                this.log("Invalid addresses: %o", bad);
-                return false;
-            }
-        }
-
-        if (!handler.parseAddr)
-            return entries;
-
-        const parsed = entries.map(([t, a]) => [t, handler.parseAddr(a)]);
-        if (!await this.subscribe(parsed.map(([, s]) => s)))
-            return false;
-
         return true;
     }
 
@@ -164,8 +168,7 @@ export class Driver {
                 this.clearAddrs();
                 await this.handler?.close?.();
 
-                this.handler = conf && this.HandlerClass.create(this, conf);
-                if (!this.handler)
+                if (!this.setupHandler(conf))
                     this.setStatus("CONF");
 
                 this.handler.connect();

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -9,7 +9,7 @@ import { Debug } from "./debug.js";
 
 export class Driver {
     constructor (opts) {
-        this.createHandler = opts.handler;
+        this.HandlerClass = opts.handler;
 
         this.status = "DOWN";
         this.clearAddrs();
@@ -97,7 +97,7 @@ export class Driver {
         return true;
     }
 
-    handleAddrs (addrs) {
+    async handleAddrs (addrs) {
         const { handler } = this;
 
         const entries = Object.entries(pkt.addrs);
@@ -107,6 +107,7 @@ export class Driver {
             if (bad.length) {
                 this.log("Invalid addresses: %o", bad);
                 return false;
+            }
         }
 
         if (!handler.parseAddr)
@@ -159,9 +160,11 @@ export class Driver {
                 this.clearAddrs();
                 await this.handler?.close?.();
 
-                this.handler = conf && this.createHandler(this, conf);
+                this.handler = conf && this.HandlerClass.create(this, conf);
                 if (!this.handler)
                     this.setStatus("CONF");
+
+                this.handler.connect();
                 break;
             }
             case "addr": {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -115,9 +115,7 @@ export class Driver {
         const st = await this.handler.connect();
         this.setStatus(st);
 
-        if (st == "UP")
-            this.reconnecting = false;
-        else
+        if (st != "UP")
             this.connFailed();
 
     }
@@ -131,6 +129,7 @@ export class Driver {
         this.reconnecting = true;
         this.log("Handler disconnected");
         await timers.setTimeout(this.reconnect);
+        this.reconnecting = false;
         this.connectHandler();
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -199,12 +199,16 @@ export class Driver {
                 this.log("CONF: %O", conf);
 
                 this.clearAddrs();
-                await this.handler?.close?.();
+                const old = this.handler;
 
-                if (!this.setupHandler(conf))
+                if (this.setupHandler(conf)) {
+                    await old?.close?.();
+                    this.connectHandler()
+                }
+                else {
                     this.setStatus("CONF");
+                }
 
-                this.connectHandler();
                 break;
             }
             case "addr": {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -3,6 +3,8 @@
  * Copyright 2024 AMRC
  */
 
+import timers from "timers/promises";
+
 import MQTT from "mqtt";
 
 import { Debug } from "./debug.js";
@@ -23,6 +25,10 @@ export class Driver {
 
         /* Overwrite this in a subclass to request driver polling */
         this.poller = null;
+
+        /* Handler reconnect timeout. This can be changed by the
+         * handler. */
+        this.reconnect = 5000;
     }
     
     run () {
@@ -91,9 +97,19 @@ export class Driver {
             this.mqtt.publish(this.topic("status"), st);
     }
 
-    connUp () { this.setStatus("UP"); }
-    connFailed () { this.setStatus("CONN"); }
-    connUnauth () { this.setStatus("AUTH"); }
+    connectHandler () {
+        this.log("Connecting handler");
+        const st = await this.handler.connect();
+        this.setStatus(st);
+        if (st != "UP")
+            this.connFailed();
+    }
+
+    connFailed () {
+        this.log("Handler disconnected");
+        await timers.setTimeout(this.reconnect);
+        this.connectHandler();
+    }
 
     clearAddrs () {
         this.addrs = null;
@@ -171,7 +187,7 @@ export class Driver {
                 if (!this.setupHandler(conf))
                     this.setStatus("CONF");
 
-                this.handler.connect();
+                this.connectHandler();
                 break;
             }
             case "addr": {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -76,7 +76,7 @@ export class Driver {
         if (!this.handler) return;
 
         const valid = this.handler.constructor.validAddrs;
-        const parse = this.handler.parseAddrs ?? a => a;
+        const parse = this.handler.parseAddrs ?? (a => a);
 
         this.handleAddrs = entries => {
             if (valid) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -167,11 +167,10 @@ export class Driver {
     }
 
     async connected () {
-        const topics = [
-            ...("active conf addr".split(" ")),
-            ...(this.poller ? ["poll"] : []),
-        ].map(() => this.topic);
-        await this.mqtt.subscribeAsync(topics);
+        const topics = "active conf addr".split(" ");
+        if (this.poller)
+            topics.push("poll");
+        await this.mqtt.subscribeAsync(topics.map(t => this.topic(t));
         this.setStatus("READY");
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -99,6 +99,8 @@ export class Driver {
             }
             return parsed;
         };
+
+        return true;
     }
 
     setStatus (st) {
@@ -170,7 +172,7 @@ export class Driver {
         const topics = "active conf addr".split(" ");
         if (this.poller)
             topics.push("poll");
-        await this.mqtt.subscribeAsync(topics.map(t => this.topic(t));
+        await this.mqtt.subscribeAsync(topics.map(t => this.topic(t)));
         this.setStatus("READY");
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -78,16 +78,26 @@ export class Driver {
         const valid = this.handler.constructor.validAddrs;
         const parse = this.handler.parseAddrs ?? (a => a);
 
-        this.handleAddrs = entries => {
+        this.handleAddrs = addrs => {
+            const entries = Object.entries(addrs);
+
             if (valid) {
-                const bad = entries.filter(([t, a]) => !valid.has(a));
+                const bad = entries.filter(([, a]) => !valid.has(a));
                 if (bad.length) {
                     this.log("Invalid addresses: %o", bad);
                     return;
                 }
             }
 
-            return entries.map(([t, a]) => [t, parse(a)]);
+            const parsed = entries.map(([t, a]) => [t, parse(a)]);
+            const bad = parsed.filter(([, s]) => !s)
+                .map(([t, ]) => addrs[t]);
+
+            if (bad.length) {
+                this.log("Invalid addresses: %o", bad);
+                return;
+            }
+            return parsed;
         };
     }
 
@@ -97,7 +107,7 @@ export class Driver {
             this.mqtt.publish(this.topic("status"), st);
     }
 
-    connectHandler () {
+    async connectHandler () {
         this.log("Connecting handler");
         const st = await this.handler.connect();
         this.setStatus(st);
@@ -105,7 +115,7 @@ export class Driver {
             this.connFailed();
     }
 
-    connFailed () {
+    async connFailed () {
         this.log("Handler disconnected");
         await timers.setTimeout(this.reconnect);
         this.connectHandler();
@@ -130,11 +140,10 @@ export class Driver {
             return false;
         }
         
-        const parsed = this.handleAddrs(Object.entries(pkt.addrs));
-        const specs = parsed.map(([, s]) => s);
-        if (parsed.some(s => !s))
-            return false;
+        const parsed = this.handleAddrs(pkt.addrs);
+        if (!parsed) return false;
 
+        const specs = parsed.map(([, s]) => s);
         if (!await this.subscribe(specs))
             return false;
         
@@ -145,10 +154,7 @@ export class Driver {
     }
 
     async subscribe (specs) {
-        if (specs.some(s => !s)) {
-            this.log("Invalid addresses: %O", pkt.addrs);
-            return false;
-        }
+        const { handler } = this;
 
         if (handler.subscribe) {
             if (!await handler.subscribe(specs)) {
@@ -164,7 +170,7 @@ export class Driver {
         const topics = [
             ...("active conf addr".split(" ")),
             ...(this.poller ? ["poll"] : []),
-        ].map(t => this.topic);
+        ].map(() => this.topic);
         await this.mqtt.subscribeAsync(topics);
         this.setStatus("READY");
     }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -77,7 +77,7 @@ export class Driver {
         if (!this.handler) return;
 
         const valid = this.handler.constructor.validAddrs;
-        const parse = this.handler.parseAddrs ?? (a => a);
+        const parse = this.handler.parseAddr ?? (a => a);
 
         this.handleAddrs = addrs => {
             const entries = Object.entries(addrs);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,0 +1,153 @@
+/* AMRC Connectivity Stack
+ * Edge Agent driver library
+ * Copyright 2024 AMRC
+ */
+
+import MQTT from "mqtt";
+
+import { Debug } from "./debug.js";
+
+export class Driver {
+    constructor (opts) {
+        this.createHandler = opts.handler;
+
+        this.status = "DOWN";
+        this.addrs = null;
+
+        const { env } = opts;
+        this.debug = new Debug({ verbose: env.VERBOSE });
+        this.log = this.debug.bound("driver");
+
+        this.id = env.EDGE_USERNAME;
+        this.mqtt = this.createMqttClient(env.EDGE_MQTT, env.EDGE_PASSWORD);
+
+        /* Overwrite this in a subclass to request driver polling */
+        this.poller = null;
+    }
+    
+    run () {
+        this.mqtt.connect();
+    }
+
+    topic (msg, data) {
+        return `fpEdge1/${this.id}/${msg}` + (data ? `/${data}` : "");
+    }
+
+    json (buf) {
+        try {
+            return JSON.parse(buf.toString());
+        }
+        catch (e) {
+            this.log("JSON parse error: %s", e);
+            return;
+        }
+    }
+
+    createMqttClient (broker, password) {
+        const mqtt = MQTT.connect({
+            url:            broker,
+            clientId:       this.id,
+            username:       this.id,
+            password:       password,
+            will:           {
+                topic:      this.topic("status"),
+                payload:    "DOWN",
+            },
+            manualConnect:  true,
+            resubscribe:    false,
+        });
+
+        mqtt.on("connect", () => this.connected());
+        mqtt.on("message", (t, p) => this.handleMessage(t, p));
+
+        return mqtt;
+    }
+
+    setStatus (st) {
+        this.status = st;
+        if (this.mqtt.connected)
+            this.mqtt.publish(this.topic("status"), st);
+    }
+
+    setAddrs (pkt) {
+        if (!this.handler) {
+            this.log("Received addrs without handler");
+            return false;
+        }
+
+        if (pkt.version != 1) {
+            this.log("Bad addr config version: %s", pkt.version);
+            return false;
+        }
+        
+        const parsed = Object.entries(pkt.addrs)
+            .map(([t, a]) => [t, this.handler.parseAddr(a)]);
+
+        if (parsed.some(([, f]) => !f)) {
+            this.log("BAD ADDRS: %O", pkt.addrs);
+            return false;
+        }
+        
+        this.addrs = new Map(parsed);
+        this.log("Set addrs: %O", this.addrs);
+        return true;
+    }
+
+    async connected () {
+        const topics = [
+            ...("active conf addr".split(" ")),
+            ...(this.poller ? ["poll"] : []),
+        ].map(t => this.topic);
+        await this.mqtt.subscribeAsync(topics);
+        this.setStatus("READY");
+    }
+
+    async handleMessage (topic, p) {
+        const [, , msg] = topic.split("/");
+        switch (msg) {
+            case "active": {
+                if (p.toString() == "ONLINE")
+                    this.setStatus("READY");
+                break;
+            }
+            case "conf": {
+                const conf = this.json(p);
+                this.log("CONF: %O", conf);
+
+                this.addrs = null;
+                await this.handler?.close?.();
+
+                this.handler = conf && this.createHandler(this, conf);
+                if (!this.handler)
+                    this.setStatus("CONF");
+                break;
+            }
+            case "addr": {
+                const a = this.json(p);
+                if (!a || !await this.setAddrs(a))
+                    this.setStatus("ADDR");
+                break;
+            }
+            case "poll": {
+                const poll = p.toString().split("\n");
+                this.log("POLL %O", poll);
+
+                if (!this.poller) {
+                    this.log("Can't poll, no poller!");
+                    return;
+                }
+                if (!this.addrs) {
+                    this.log("Can't poll, no addrs!");
+                    return;
+                }
+                poll.map(t => ({
+                        data: this.topic("data", t),
+                        spec: this.addrs.get(t),
+                    }))
+                    .filter(v => v.spec)
+                    .forEach(this.poller);
+                break;
+            }
+        }
+    }
+}

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -29,6 +29,7 @@ export class Driver {
         /* Handler reconnect timeout. This can be changed by the
          * handler. */
         this.reconnect = 5000;
+        this.reconnecting = false;
     }
     
     run () {
@@ -113,11 +114,21 @@ export class Driver {
         this.log("Connecting handler");
         const st = await this.handler.connect();
         this.setStatus(st);
-        if (st != "UP")
+
+        if (st == "UP")
+            this.reconnecting = false;
+        else
             this.connFailed();
+
     }
 
     async connFailed () {
+        if (this.reconnecting) {
+            this.log("Handler already reconnecting");
+            return;
+        }
+            
+        this.reconnecting = true;
         this.log("Handler disconnected");
         await timers.setTimeout(this.reconnect);
         this.connectHandler();

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,5 +3,6 @@
  * Copyright 2024 AMRC
  */
 
+export * from "./bufferx.js";
 export * from "./debug.js";
 export * from "./polled.js";

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
  * Copyright 2024 AMRC
  */
 
+export * from "./async.js";
 export * from "./bufferx.js";
 export * from "./debug.js";
 export * from "./polled.js";

--- a/lib/polled.js
+++ b/lib/polled.js
@@ -4,65 +4,17 @@
  */
 
 import asyncjs from "async";
-import MQTT from "mqtt";
 
-import { Debug } from "./debug.js";
+import { Driver } from "./driver.js";
 
 const Q_TIMEOUT = 30000;
 const Q_MAX = 20;
 
-export class PolledDriver {
+export class PolledDriver extends Driver {
     constructor (opts) {
-        this.createHandler = opts.handler;
+        super(opts);
 
-        this.status = "DOWN";
-        this.addrs = null;
-
-        const { env } = opts;
-        this.debug = new Debug({ verbose: env.VERBOSE });
-        this.log = this.debug.bound("driver");
-
-        this.id = env.EDGE_USERNAME;
-        this.mqtt = this.createMqttClient(env.EDGE_MQTT, env.EDGE_PASSWORD);
         this.poller = this.createPoller(opts);
-    }
-
-    run () {
-        this.mqtt.connect();
-    }
-
-    topic (msg, data) {
-        return `fpEdge1/${this.id}/${msg}` + (data ? `/${data}` : "");
-    }
-
-    json (buf) {
-        try {
-            return JSON.parse(buf.toString());
-        }
-        catch (e) {
-            this.log("JSON parse error: %s", e);
-            return;
-        }
-    }
-
-    createMqttClient (broker, password) {
-        const mqtt = MQTT.connect({
-            url:            broker,
-            clientId:       this.id,
-            username:       this.id,
-            password:       password,
-            will:           {
-                topic:      this.topic("status"),
-                payload:    "DOWN",
-            },
-            manualConnect:  true,
-            resubscribe:    false,
-        });
-
-        mqtt.on("connect", () => this.connected());
-        mqtt.on("message", (t, p) => this.handleMessage(t, p));
-
-        return mqtt;
     }
 
     createPoller (opts) {
@@ -85,36 +37,6 @@ export class PolledDriver {
         this.log("POLL ERR: %o", e);
     }
 
-    setStatus (st) {
-        this.status = st;
-        if (this.mqtt.connected)
-            this.mqtt.publish(this.topic("status"), st);
-    }
-
-    setAddrs (pkt) {
-        if (!this.handler) {
-            this.log("Received addrs without handler");
-            return false;
-        }
-
-        if (pkt.version != 1) {
-            this.log("Bad addr config version: %s", pkt.version);
-            return false;
-        }
-        
-        const parsed = Object.entries(pkt.addrs)
-            .map(([t, a]) => [t, this.handler.parseAddr(a)]);
-
-        if (parsed.some(([, f]) => !f)) {
-            this.log("BAD ADDRS: %O", pkt.addrs);
-            return false;
-        }
-        
-        this.addrs = new Map(parsed);
-        this.log("Set addrs: %O", this.addrs);
-        return true;
-    }
-
     async poll ({ data, spec }) {
         this.log("READ %O", spec);
         const buf = await this.handler.poll(spec);
@@ -122,56 +44,5 @@ export class PolledDriver {
         this.log("DATA %O", buf);
         if (buf)
             await this.mqtt.publishAsync(data, buf);
-    }
-
-    async connected () {
-        await this.mqtt.subscribeAsync(
-            "active conf addr poll"
-                .split(" ")
-                .map(t => this.topic(t)));
-        this.setStatus("READY");
-    }
-
-    async handleMessage (topic, p) {
-        const [, , msg] = topic.split("/");
-        switch (msg) {
-            case "active": {
-                if (p.toString() == "ONLINE")
-                    this.setStatus("READY");
-                break;
-            }
-            case "conf": {
-                const conf = this.json(p);
-                this.log("CONF: %O", conf);
-
-                this.addrs = null;
-                await this.handler?.close?.();
-
-                this.handler = conf && this.createHandler(this, conf);
-                if (!this.handler)
-                    this.setStatus("CONF");
-                break;
-            }
-            case "addr": {
-                const a = this.json(p);
-                if (!a || !this.setAddrs(a))
-                    this.setStatus("CONF");
-                break;
-            }
-            case "poll": {
-                const poll = p.toString().split("\n");
-                this.log("POLL %O", poll);
-                if (this.addrs)
-                    poll.map(t => ({
-                            data: this.topic("data", t),
-                            spec: this.addrs.get(t),
-                        }))
-                        .filter(v => v.spec)
-                        .forEach(this.poller);
-                else
-                    this.log("Can't poll, no addrs!");
-                break;
-            }
-        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/edge-driver",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "lib/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/edge-driver",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "lib/index.js",
   "type": "module",


### PR DESCRIPTION
Refactor most of PolledDriver into a Driver superclass. Create a new AsyncDriver subclass supporting drivers like MQTT which always produce data asynchronously.

Make some quite substantial API changes: now is the time to do this. Replace the factory function with a static class method; this will be easier to understand. Require an explicit `connect` method on the handler. Handle reconnection on connection failure in the driver by calling `connect` on the handler again.

Export some Buffer creation utility functions.