### PR TITLE
Support callback APIs better

### DIFF
--- a/docs/driver.md
+++ b/docs/driver.md
@@ -198,19 +198,16 @@ to set up subscriptions to the southbound device.
 ### `close`
 
     await handler.close();
+    handler.close(done);
 
 This method is optional.
 
 If this method exists it is called when a new configuration is received,
-just before the old handler object will be unreferenced. The result will
-be awaited before a new handler is created. This should perform any
-cleanup (closing connections, etc.) and ensure this is complete before
-the returned Promise resolves.
+just before the old handler object will be unreferenced. The method should
+perform any cleanup (closing connections, etc.) needed before
+reconnecting.
 
-If and when the [TC39 Explicit Resource Management
-proposal](https://github.com/tc39/proposal-explicit-resource-management)
-is accepted and becomes available in Node.js, the `close` method is
-likely to be supplemented by `Symbol.asyncDispose`. A handler object
-implementing `@@asyncDispose` or `@@dispose` should clean up correctly
-when any single disposal method is called.
+The method supports both Promise-based and callback-based APIs. The
+method is passed a callback, which can be called to indicate cleanup is
+finished. Alternatively the method can return a Promise.
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -240,7 +240,14 @@ export class Driver {
             const old = this.handler;
 
             if (this.setupHandler(conf)) {
-                await old?.close?.();
+                const closer = old?.close;
+                if (closer) {
+                    /* Support both Promise and callback APIs */
+                    await new Promise(resolve => {
+                        const pr = closer.call(old, resolve);
+                        if (pr) resolve(pr);
+                    });
+                }
                 this.connectHandler()
             }
             else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -9,6 +9,9 @@ import MQTT from "mqtt";
 
 import { Debug } from "./debug.js";
 
+/* Permitted status returns from Handler.connect */
+const CONNECT_STATUS = new Set(["UP", "CONN", "AUTH"]);
+
 export class Driver {
     constructor (opts) {
         this.HandlerClass = opts.handler;
@@ -111,15 +114,38 @@ export class Driver {
 
     async connectHandler () {
         this.log("Connecting handler");
-        const st = await this.handler.connect();
-        this.setStatus(st);
+        const pr = this.handler.connect();
+
+        /* If the handler doesn't return a Promise, it wants to use
+         * callbacks. */
+        if (!pr) return;
+
+        /* If we get a promise (or a plain string), await it and set our
+         * status. */
+        const st = await pr;
+        if (CONNECT_STATUS.has(st))
+            this.setStatus(st);
+        else
+            this.log("Handler.connect returned invalid value: %o", st);
 
         if (st != "UP")
-            this.connFailed();
+            this.reconnectHandler();
 
     }
 
-    async connFailed () {
+    connUp () {
+        this.setStatus("UP");
+    }
+    connFailed () {
+        this.setStatus("CONN");
+        this.reconnectHandler();
+    }
+    connUnauth () {
+        this.setStatus("AUTH");
+        this.reconnectHandler();
+    }
+
+    async reconnectHandler () {
         if (this.reconnecting) {
             this.log("Handler already reconnecting");
             return;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -51,8 +51,7 @@ export class Driver {
     }
 
     createMqttClient (broker, password) {
-        const mqtt = MQTT.connect({
-            url:            broker,
+        const mqtt = MQTT.connect(broker, {
             clientId:       this.id,
             username:       this.id,
             password:       password,

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -26,15 +26,15 @@ export class Driver {
         this.id = env.EDGE_USERNAME;
         this.mqtt = this.createMqttClient(env.EDGE_MQTT, env.EDGE_PASSWORD);
 
-        /* Overwrite this in a subclass to request driver polling */
-        this.poller = null;
+        this.messageHandlers = new Map();
+        this.setupMessageHandlers();
 
         /* Handler reconnect timeout. This can be changed by the
          * handler. */
         this.reconnect = 5000;
         this.reconnecting = false;
     }
-    
+
     run () {
         this.mqtt.connect();
     }
@@ -204,64 +204,53 @@ export class Driver {
     }
 
     async connected () {
-        const topics = "active conf addr".split(" ");
-        if (this.poller)
-            topics.push("poll");
-        await this.mqtt.subscribeAsync(topics.map(t => this.topic(t)));
+        const topics = [...this.messageHandlers.keys()]
+            .map(t => this.topic(t));
+        await this.mqtt.subscribeAsync(topics);
         this.setStatus("READY");
     }
 
-    async handleMessage (topic, p) {
-        const [, , msg] = topic.split("/");
-        switch (msg) {
-            case "active": {
-                if (p.toString() == "ONLINE")
-                    this.setStatus("READY");
-                break;
-            }
-            case "conf": {
-                const conf = this.json(p);
-                this.log("CONF: %O", conf);
+    handleMessage (topic, p) {
+        const [, , msg, data] = topic.split("/");
 
-                this.clearAddrs();
-                const old = this.handler;
-
-                if (this.setupHandler(conf)) {
-                    await old?.close?.();
-                    this.connectHandler()
-                }
-                else {
-                    this.setStatus("CONF");
-                }
-
-                break;
-            }
-            case "addr": {
-                const a = this.json(p);
-                if (!a || !await this.setAddrs(a))
-                    this.setStatus("ADDR");
-                break;
-            }
-            case "poll": {
-                const poll = p.toString().split("\n");
-                this.log("POLL %O", poll);
-
-                if (!this.poller) {
-                    this.log("Can't poll, no poller!");
-                    return;
-                }
-                if (!this.addrs) {
-                    this.log("Can't poll, no addrs!");
-                    return;
-                }
-                poll.map(t => ({
-                        data: this.topic("data", t),
-                        spec: this.addrs.get(t),
-                    }))
-                    .filter(v => v.spec)
-                    .forEach(this.poller);
-                break;
-            }
+        const h = this.messageHandlers.get(msg);
+        if (!h) {
+            this.log("Unhandled driver message: %s", msg);
+            return;
         }
+
+        h(p, data);
+    }
+
+    message (msg, handler) {
+        this.messageHandlers.set(msg, handler);
+    }
+
+    /* Override this method to change the message handlers we use */
+    setupMessageHandlers () {
+        this.message("active", p => {
+            if (p.toString() == "ONLINE")
+                this.setStatus("READY");
+        });
+        this.message("conf", async p => {
+            const conf = this.json(p);
+            this.log("CONF: %O", conf);
+
+            this.clearAddrs();
+            const old = this.handler;
+
+            if (this.setupHandler(conf)) {
+                await old?.close?.();
+                this.connectHandler()
+            }
+            else {
+                this.setStatus("CONF");
+            }
+        });
+        this.message("addr", async p => {
+            const a = this.json(p);
+            if (!a || !await this.setAddrs(a))
+                this.setStatus("ADDR");
+        });
     }
 }

--- a/lib/polled.js
+++ b/lib/polled.js
@@ -37,6 +37,29 @@ export class PolledDriver extends Driver {
         this.log("POLL ERR: %o", e);
     }
 
+    setupMessageHandlers () {
+        super.setupMessageHandlers();
+        this.message("poll", p => {
+            const poll = p.toString().split("\n");
+            this.log("POLL %O", poll);
+
+            if (!this.poller) {
+                this.log("Can't poll, no poller!");
+                return;
+            }
+            if (!this.addrs) {
+                this.log("Can't poll, no addrs!");
+                return;
+            }
+            poll.map(t => ({
+                    data: this.topic("data", t),
+                    spec: this.addrs.get(t),
+                }))
+                .filter(v => v.spec)
+                .forEach(this.poller);
+        });
+    }
+
     async poll ({ data, spec }) {
         this.log("READ %O", spec);
         const buf = await this.handler.poll(spec);


### PR DESCRIPTION
A lot of JS libraries still use callback APIs. Make it easier to support these by providing a callback interface as well as a Promise interface.