### PR TITLE
Queue poll requests in batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+config.mk
 node_modules
 .env
 .idea

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+sinclude config.mk
+
 check-committed:
 	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
 
@@ -10,3 +12,6 @@ publish: check-committed lint
 
 amend:
 	git commit -C HEAD -a --amend
+
+pubdev: check-committed lint
+	sh ./tools/pub-dev.sh "${js.dev_tag}"

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -251,6 +251,7 @@ export class Driver {
                 this.connectHandler()
             }
             else {
+                this.log("Handler rejected driver configuration!");
                 this.setStatus("CONF");
             }
         });

--- a/lib/polled.js
+++ b/lib/polled.js
@@ -47,25 +47,31 @@ export class PolledDriver extends Driver {
                 this.log("Can't poll, no poller!");
                 return;
             }
-            if (!this.addrs) {
-                this.log("Can't poll, no addrs!");
-                return;
-            }
-            poll.map(t => ({
-                    data: this.topic("data", t),
-                    spec: this.addrs.get(t),
-                }))
-                .filter(v => v.spec)
-                .forEach(this.poller);
+            this.poller(poll);
+
         });
     }
 
-    async poll ({ data, spec }) {
-        this.log("READ %O", spec);
-        const buf = await this.handler.poll(spec);
+    async poll (poll) {
+        if (!this.addrs) {
+            this.log("Can't poll, no addrs!");
+            return;
+        }
 
-        this.log("DATA %O", buf);
-        if (buf)
-            await this.mqtt.publishAsync(data, buf);
+        const specs = poll
+            .map(t => ({
+                data: this.topic("data", t),
+                spec: this.addrs.get(t),
+            }))
+            .filter(v => v.spec);
+
+        for (const {data, spec} of specs) {
+            this.log("READ %O", spec);
+            const buf = await this.handler.poll(spec);
+
+            this.log("DATA %O", buf);
+            if (buf)
+                await this.mqtt.publishAsync(data, buf);
+        }
     }
 }

--- a/lib/polled.js
+++ b/lib/polled.js
@@ -26,7 +26,7 @@ export class PolledDriver extends Driver {
             q.error(err);
             return a => q.length() < Q_MAX
                 ? q.push(a)
-                : err("Poll queue size exceeded");
+                : err("Poll queue size exceeded. We're polling too fast for the device!");
         }
         else {
             return a => do_poll(a, err);
@@ -48,13 +48,12 @@ export class PolledDriver extends Driver {
                 return;
             }
             this.poller(poll);
-
         });
     }
 
     async poll (poll) {
         if (!this.addrs) {
-            this.log("Can't poll, no addrs!");
+            this.log("Can't poll, no addrs! Is the device config invalid?");
             return;
         }
 

--- a/lib/polled.js
+++ b/lib/polled.js
@@ -25,7 +25,8 @@ export class PolledDriver extends Driver {
             const q = asyncjs.queue(do_poll);
             q.error(err);
             return a => q.length() < Q_MAX
-                ? q.push(a)
+                    /* grr stupid api */
+                ? q.push([a])
                 : err("Poll queue size exceeded. We're polling too fast for the device!");
         }
         else {
@@ -40,24 +41,24 @@ export class PolledDriver extends Driver {
     setupMessageHandlers () {
         super.setupMessageHandlers();
         this.message("poll", p => {
-            const poll = p.toString().split("\n");
-            this.log("POLL %O", poll);
+            const topics = p.toString().split("\n");
+            this.log("POLL %O", topics);
 
             if (!this.poller) {
                 this.log("Can't poll, no poller!");
                 return;
             }
-            this.poller(poll);
+            this.poller(topics);
         });
     }
 
-    async poll (poll) {
+    async poll (topics) {
         if (!this.addrs) {
             this.log("Can't poll, no addrs! Is the device config invalid?");
             return;
         }
 
-        const specs = poll
+        const specs = topics
             .map(t => ({
                 data: this.topic("data", t),
                 spec: this.addrs.get(t),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amrc-factoryplus/edge-driver",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amrc-factoryplus/edge-driver",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
         "async": "^3.2.5",

--- a/tools/pub-dev.sh
+++ b/tools/pub-dev.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -ex
+
+tag="$1"
+if [ -z "$tag" ]
+then
+    echo "Set js.dev_tag in config.mk!" >&2
+    exit 1
+fi
+
+cp package.json ~package.json~
+sed -e's/"version": .*/"version": "'"$tag"'",/' \
+        < ~package.json~ >package.json
+npm publish
+mv ~package.json~ package.json
+
+ix="${tag##*.}"
+sed -i -re'/^js\.dev_tag=/s/[^.]*$/'"$(( ix + 1 ))"'/' config.mk


### PR DESCRIPTION
When we are polling serially we need to queue poll requests. We need to
limit the queue size for sanity reasons; if we're overrunning the queue
the device isn't keeping up with the poll requests. However, with addrs
queued individually we were quickly overrunning the queue on devices
with many addrs.

Instead, queue each poll request in full. This means processing a queue
item will take longer, and there's more chance of hitting the 30s
backstop timeout, but we have to enforce limits somehow.